### PR TITLE
Add option analysis module and unit tests

### DIFF
--- a/option_analysis.py
+++ b/option_analysis.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+"""Utilities for analysing SPY option contracts."""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+from dataclasses import dataclass
+from typing import List, Optional
+
+import yfinance as yf
+
+
+def _norm_cdf(x: float) -> float:
+    """Cumulative distribution function for the standard normal distribution."""
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def black_scholes_price(
+    S: float,
+    K: float,
+    T: float,
+    r: float,
+    sigma: float,
+    option_type: str = "call",
+) -> float:
+    """Return Black-Scholes option price."""
+    if T <= 0:
+        if option_type == "call":
+            return max(S - K, 0.0)
+        return max(K - S, 0.0)
+
+    d1 = (math.log(S / K) + (r + 0.5 * sigma ** 2) * T) / (sigma * math.sqrt(T))
+    d2 = d1 - sigma * math.sqrt(T)
+
+    if option_type == "call":
+        return S * _norm_cdf(d1) - K * math.exp(-r * T) * _norm_cdf(d2)
+    return K * math.exp(-r * T) * _norm_cdf(-d2) - S * _norm_cdf(-d1)
+
+
+def black_scholes_d2(S: float, K: float, T: float, r: float, sigma: float) -> float:
+    """Return the d2 term used in Black-Scholes."""
+    if T <= 0:
+        return -float("inf")
+    d1 = (math.log(S / K) + (r + 0.5 * sigma ** 2) * T) / (sigma * math.sqrt(T))
+    return d1 - sigma * math.sqrt(T)
+
+
+@dataclass
+class OptionContract:
+    """Simplified option contract description."""
+
+    strike: float
+    last_price: float
+    iv: float
+    expiry: dt.date
+    option_type: str  # "call" or "put"
+    underlying_price: float
+
+
+@dataclass
+class OptionAnalysis:
+    """Computed statistics for an option."""
+
+    strike: float
+    last_price: float
+    iv: float
+    expiry: dt.date
+    underlying_price: float
+    pop: float
+    intrinsic_value: float
+    time_value: float
+
+
+def compute_option_metrics(
+    option: OptionContract, r: float = 0.05, today: Optional[dt.date] = None
+) -> OptionAnalysis:
+    """Return computed metrics for a given option contract."""
+    if today is None:
+        today = dt.date.today()
+    T = max((option.expiry - today).days / 365.0, 0.0)
+
+    d2 = black_scholes_d2(option.underlying_price, option.strike, T, r, option.iv)
+    pop = _norm_cdf(d2)
+
+    if option.option_type == "call":
+        intrinsic = max(option.underlying_price - option.strike, 0.0)
+    else:
+        intrinsic = max(option.strike - option.underlying_price, 0.0)
+    time_value = option.last_price - intrinsic
+
+    return OptionAnalysis(
+        strike=option.strike,
+        last_price=option.last_price,
+        iv=option.iv,
+        expiry=option.expiry,
+        underlying_price=option.underlying_price,
+        pop=pop,
+        intrinsic_value=intrinsic,
+        time_value=time_value,
+    )
+
+
+def get_call_option_analysis(r: float = 0.05) -> List[OptionAnalysis]:
+    """Fetch SPY call options for the nearest expiry and compute metrics."""
+    ticker = yf.Ticker("SPY")
+    expiries = ticker.options
+    if not expiries:
+        raise RuntimeError("No expiries found for SPY")
+    expiry_str = expiries[0]
+    expiry_date = dt.datetime.strptime(expiry_str, "%Y-%m-%d").date()
+
+    underlying = float(ticker.history(period="1d")["Close"].iloc[-1])
+    chain = ticker.option_chain(expiry_str).calls
+
+    results: List[OptionAnalysis] = []
+    T = max((expiry_date - dt.date.today()).days / 365.0, 0.0)
+    for _, row in chain.iterrows():
+        strike = float(row["strike"])
+        price = float(row["lastPrice"])
+        iv = float(row.get("impliedVolatility", 0.0))
+        d2 = black_scholes_d2(underlying, strike, T, r, iv)
+        pop = _norm_cdf(d2)
+        intrinsic = max(underlying - strike, 0.0)
+        time_value = price - intrinsic
+        results.append(
+            OptionAnalysis(
+                strike=strike,
+                last_price=price,
+                iv=iv,
+                expiry=expiry_date,
+                underlying_price=underlying,
+                pop=pop,
+                intrinsic_value=intrinsic,
+                time_value=time_value,
+            )
+        )
+    return results
+
+
+def simulate_value_decay(
+    option: OptionContract, days: List[int], r: float = 0.05
+) -> List[float]:
+    """Return theoretical option prices as time to expiry decreases."""
+    prices: List[float] = []
+    for d in days:
+        T = max(d / 365.0, 0.0)
+        price = black_scholes_price(
+            option.underlying_price,
+            option.strike,
+            T,
+            r,
+            option.iv,
+            option.option_type,
+        )
+        prices.append(price)
+    return prices
+
+__all__ = [
+    "OptionContract",
+    "OptionAnalysis",
+    "black_scholes_price",
+    "compute_option_metrics",
+    "get_call_option_analysis",
+    "simulate_value_decay",
+]
+

--- a/test_option_analysis.py
+++ b/test_option_analysis.py
@@ -1,0 +1,51 @@
+import datetime as dt
+import unittest
+
+import option_analysis as oa
+
+
+class OptionAnalysisTests(unittest.TestCase):
+    def setUp(self):
+        self.today = dt.date.today()
+        self.expiry = self.today + dt.timedelta(days=21)
+        self.underlying = 430.0
+        self.iv = 0.25
+
+    def _make_option(self, strike: float) -> oa.OptionContract:
+        T = 21 / 365
+        price = oa.black_scholes_price(
+            self.underlying, strike, T, 0.05, self.iv, option_type="call"
+        )
+        return oa.OptionContract(
+            strike=strike,
+            last_price=price,
+            iv=self.iv,
+            expiry=self.expiry,
+            option_type="call",
+            underlying_price=self.underlying,
+        )
+
+    def test_pop_decreases_with_strike(self):
+        opt_low = self._make_option(430)
+        opt_high = self._make_option(440)
+        stats_low = oa.compute_option_metrics(opt_low, today=self.today)
+        stats_high = oa.compute_option_metrics(opt_high, today=self.today)
+        self.assertGreater(stats_low.pop, stats_high.pop)
+
+    def test_intrinsic_value(self):
+        opt = self._make_option(435)
+        stats = oa.compute_option_metrics(opt, today=self.today)
+        self.assertEqual(stats.intrinsic_value, 0.0)
+
+    def test_time_value_decay(self):
+        opt = self._make_option(435)
+        prices = oa.simulate_value_decay(opt, [21, 10, 1])
+        intrinsic = max(self.underlying - 435, 0)
+        time_values = [p - intrinsic for p in prices]
+        self.assertGreater(time_values[0], time_values[1])
+        self.assertGreater(time_values[1], time_values[2])
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- implement `option_analysis.py` for fetching SPY call chain and computing metrics
- include Black-Scholes pricing utilities and PoP calculation
- add helper to simulate value decay over time
- provide tests covering PoP behaviour, intrinsic value and time decay

## Testing
- `python -m unittest -v`