### PR TITLE
Enhance option analysis with expiry filters

### DIFF
--- a/models.py
+++ b/models.py
@@ -30,3 +30,4 @@ class OptionAnalysis:
     pop: float
     intrinsic_value: float
     time_value: float
+    days_to_expiry: int

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -49,6 +49,24 @@ class OptionAnalysisTests(unittest.TestCase):
         self.assertGreater(time_values[0], time_values[1])
         self.assertGreater(time_values[1], time_values[2])
 
+    def test_days_to_expiry(self):
+        opt = self._make_option(435)
+        stats = oa.compute_option_metrics(opt, today=self.today)
+        self.assertEqual(stats.days_to_expiry, 21)
+
+    def test_filter_options_by_pop_and_timevalue_percent(self):
+        opt1 = self._make_option(420)
+        opt2 = self._make_option(435)
+        stats = [
+            oa.compute_option_metrics(opt1, today=self.today),
+            oa.compute_option_metrics(opt2, today=self.today),
+        ]
+        filtered = oa.filter_options_by_pop_and_timevalue_percent(
+            stats, pop_threshold=0.65, tv_threshold=0.25
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertAlmostEqual(filtered[0].strike, 420)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `days_to_expiry` to `OptionAnalysis`
- implement market-day expiry selection
- return metrics for multiple expiries and add filtering helpers
- update CLI to show filtered options and save CSV
- expand tests for new functionality

## Testing
- `python -m pytest -q`