### PR TITLE
Add credit spread module and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ python spy_options.py
 
 By default the script chooses the closest expiry and prints the best call
 option based on the simple heuristic above.
+
+## Credit-spread screener
+
+The `cli.py` script screens SPY bull-put or bear-call credit spreads by probability-of-profit and credit percentage.
+
+Example:
+
+```bash
+python cli.py --type bull_put --pop 0.70 --credit 30
+```

--- a/spread_analysis.py
+++ b/spread_analysis.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import datetime as dt
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional
+
+import yfinance as yf
+
+from models import OptionContract
+import option_analysis as oa
+
+
+def _norm_cdf(x: float) -> float:
+    """Cumulative normal distribution function."""
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+class SpreadType(str, Enum):
+    BULL_PUT = "bull_put"
+    BEAR_CALL = "bear_call"
+
+
+@dataclass
+class Spread:
+    type: SpreadType
+    short: OptionContract
+    long: OptionContract
+    width: float
+    credit: float
+    max_loss: float
+    credit_pct: float
+    pop: float
+    days_to_expiry: int
+
+
+def make_spread(
+    spread_type: SpreadType,
+    short: OptionContract,
+    long: OptionContract,
+    r: float = 0.05,
+    today: Optional[dt.date] = None,
+) -> Spread:
+    """Build a Spread object from two option legs."""
+    if today is None:
+        today = dt.date.today()
+    width = abs(long.strike - short.strike)
+    credit = short.last_price - long.last_price
+    max_loss = width - credit
+    # credit percentage relative to spread width
+    credit_pct = credit / width * 100 if width else 0.0
+    days_to_expiry = max((short.expiry - today).days, 0)
+    T = days_to_expiry / 365.0
+    d2 = oa.black_scholes_d2(short.underlying_price, short.strike, T, r, short.iv)
+    if spread_type == SpreadType.BULL_PUT:
+        pop = _norm_cdf(d2)
+    else:
+        pop = _norm_cdf(-d2)
+    return Spread(
+        type=spread_type,
+        short=short,
+        long=long,
+        width=width,
+        credit=credit,
+        max_loss=max_loss,
+        credit_pct=credit_pct,
+        pop=pop,
+        days_to_expiry=days_to_expiry,
+    )
+
+
+def get_credit_spreads(
+    expiry: str,
+    width: float = 5.0,
+    spread_type: SpreadType = SpreadType.BULL_PUT,
+) -> List[Spread]:
+    """Return credit spreads for the given expiry and width."""
+    ticker = yf.Ticker("SPY")
+    underlying = float(ticker.history(period="1d")["Close"].iloc[-1])
+    chain = ticker.option_chain(expiry)
+    df = chain.puts if spread_type == SpreadType.BULL_PUT else chain.calls
+    expiry_date = dt.datetime.strptime(expiry, "%Y-%m-%d").date()
+
+    options = {}
+    for _, row in df.iterrows():
+        strike = float(row["strike"])
+        opt = OptionContract(
+            strike=strike,
+            expiry=expiry_date,
+            option_type="put" if spread_type == SpreadType.BULL_PUT else "call",
+            last_price=float(row["lastPrice"]),
+            iv=float(row.get("impliedVolatility", 0.0)),
+            underlying_price=underlying,
+        )
+        options[strike] = opt
+
+    spreads: List[Spread] = []
+    for strike, short in options.items():
+        long_strike = strike - width if spread_type == SpreadType.BULL_PUT else strike + width
+        long = options.get(long_strike)
+        if long is None:
+            continue
+        if short.iv == 0 or long.iv == 0 or short.last_price == 0 or long.last_price == 0:
+            continue
+        spreads.append(make_spread(spread_type, short, long))
+    return spreads
+
+
+def filter_credit_spreads(
+    spreads: List[Spread],
+    pop_min: float = 0.65,
+    credit_min_pct: float = 25.0,
+) -> List[Spread]:
+    """Filter spreads by probability of profit and credit percentage."""
+    filtered = [
+        s
+        for s in spreads
+        if s.pop >= pop_min and s.credit_pct >= credit_min_pct
+    ]
+    filtered.sort(key=lambda s: (-s.pop, -s.credit_pct))
+    return filtered
+
+
+__all__ = [
+    "SpreadType",
+    "Spread",
+    "make_spread",
+    "get_credit_spreads",
+    "filter_credit_spreads",
+]

--- a/tests/test_spread.py
+++ b/tests/test_spread.py
@@ -1,0 +1,59 @@
+import datetime as dt
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from models import OptionContract
+import spread_analysis as sa
+
+
+class SpreadTests(unittest.TestCase):
+    def setUp(self):
+        self.today = dt.date.today()
+        self.expiry = self.today + dt.timedelta(days=10)
+        self.underlying = 100.0
+        self.iv = 0.25
+
+    def _make_option(self, strike: float, price: float) -> OptionContract:
+        return OptionContract(
+            strike=strike,
+            expiry=self.expiry,
+            option_type="put",
+            last_price=price,
+            iv=self.iv,
+            underlying_price=self.underlying,
+        )
+
+    def test_spread_values(self):
+        short = self._make_option(100, 3.0)
+        long = self._make_option(95, 1.0)
+        spread = sa.make_spread(sa.SpreadType.BULL_PUT, short, long, today=self.today)
+        self.assertAlmostEqual(spread.credit, 2.0)
+        self.assertAlmostEqual(spread.width, 5.0)
+        self.assertAlmostEqual(spread.credit_pct, 40.0)
+
+    def test_pop_decreases_with_strike(self):
+        short1 = self._make_option(100, 3.0)
+        long1 = self._make_option(95, 1.0)
+        spread1 = sa.make_spread(sa.SpreadType.BULL_PUT, short1, long1, today=self.today)
+
+        short2 = self._make_option(105, 3.0)
+        long2 = self._make_option(100, 1.0)
+        spread2 = sa.make_spread(sa.SpreadType.BULL_PUT, short2, long2, today=self.today)
+
+        self.assertGreater(spread1.pop, spread2.pop)
+
+    def test_filter_credit_spreads(self):
+        short = self._make_option(100, 3.0)
+        long = self._make_option(95, 1.0)
+        s1 = sa.make_spread(sa.SpreadType.BULL_PUT, short, long, today=self.today)
+        s2 = sa.make_spread(sa.SpreadType.BULL_PUT, short, self._make_option(99, 2.8), today=self.today)
+        spreads = sa.filter_credit_spreads([s1, s2], pop_min=0.0, credit_min_pct=30.0)
+        self.assertEqual(spreads[0], s1)
+        self.assertEqual(len(spreads), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `spread_analysis.py` with helpers for screening bull-put and bear-call credit spreads
- add command line interface in `cli.py`
- document credit spread screener usage
- add unit tests for spread calculations and filtering

## Testing
- `pytest -q`