### PR TITLE
Add IV fallback and source tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ Example:
 ```bash
 python cli.py --type bull_put --pop 0.70 --credit 30
 ```
+
+### IV handling
+The screener replaces missing or near-zero implied volatility in two stages:
+
+| Source tag | Meaning |
+|------------|---------|
+| `orig` | IV came directly from Yahoo option chain |
+| `atm`  | Missing IV replaced by at-the-money IV for that expiry |
+| `vix`  | Still missing → replaced by VIX-based σ scaled to expiry |
+
+Use `--min-iv` (default 0.05) to set the minimum acceptable IV after fallback.
+

--- a/models.py
+++ b/models.py
@@ -4,6 +4,8 @@ import datetime as dt
 from dataclasses import dataclass
 from typing import Optional
 
+from vol_utils import IVSource
+
 @dataclass
 class OptionContract:
     """Generic option contract information."""
@@ -13,6 +15,7 @@ class OptionContract:
     option_type: str  # "call" or "put"
     last_price: float
     iv: Optional[float] = None
+    iv_src: IVSource | None = None
     underlying_price: Optional[float] = None
     symbol: Optional[str] = None
     open_interest: Optional[int] = None

--- a/tests/test_spread.py
+++ b/tests/test_spread.py
@@ -58,12 +58,12 @@ class SpreadTests(unittest.TestCase):
         import pandas as pd
         from unittest.mock import patch
 
-        # fake option chain with zero IV on long leg
+        # fake option chain with zero IVs so fallback also fails
         df = pd.DataFrame(
             {
                 "strike": [100, 95],
                 "lastPrice": [2.0, 0.5],
-                "impliedVolatility": [0.25, 0.0],
+                "impliedVolatility": [0.0, 0.0],
             }
         )
 
@@ -79,7 +79,10 @@ class SpreadTests(unittest.TestCase):
             def option_chain(self, expiry):
                 return FakeChain(df)
 
-        with patch("yfinance.Ticker", return_value=FakeTicker()):
+        with patch("yfinance.Ticker", return_value=FakeTicker()), patch(
+            "vol_utils.vix_sigma",
+            return_value=0.0,
+        ):
             spreads = sa.get_credit_spreads(
                 "2099-01-01", width=5.0, spread_type=sa.SpreadType.BULL_PUT
             )

--- a/tests/test_vol.py
+++ b/tests/test_vol.py
@@ -1,0 +1,37 @@
+import math
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from vol_utils import resolve_iv, IVSource
+
+
+class VolUtilsTests(unittest.TestCase):
+    def test_resolve_iv_atm(self):
+        chain = pd.DataFrame({"strike": [100, 105], "impliedVolatility": [0.2, 0.21]})
+        iv, src = resolve_iv(0.0, chain, spot=102, days=10)
+        self.assertEqual(src, IVSource.ATM)
+        self.assertAlmostEqual(iv, 0.2, places=3)
+
+    def test_resolve_iv_vix(self):
+        chain = pd.DataFrame({"strike": [], "impliedVolatility": []})
+        with patch("vol_utils.yf.Ticker") as FakeTicker:
+            FakeTicker.return_value.history.return_value = pd.DataFrame({"Close": [20.0]})
+            iv, src = resolve_iv(0.0, chain, spot=100, days=15)
+        expected = 0.20 * math.sqrt(15 / 30.0)
+        self.assertEqual(src, IVSource.VIX)
+        self.assertAlmostEqual(iv, expected, places=6)
+
+    def test_cli_help_heading(self):
+        import subprocess
+        result = subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), "..", "cli.py"), "--help"], capture_output=True, text=True)
+        self.assertIn("~", result.stdout)
+        self.assertNotIn("\u2248", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vol_utils.py
+++ b/vol_utils.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import math
+from enum import Enum
+
+import numpy as np
+import yfinance as yf
+
+MIN_IV_DEFAULT = 0.05  # 5 %
+
+class IVSource(str, Enum):
+    ORIG = "orig"
+    ATM = "atm"
+    VIX = "vix"
+
+
+def iv_is_valid(iv: float | None, floor: float = MIN_IV_DEFAULT) -> bool:
+    """Return True if IV is usable (not None/NaN and >= floor)."""
+    return iv is not None and iv >= floor and not math.isnan(iv)
+
+
+def get_atm_iv(chain_df, spot):
+    """Return IV of strike closest to spot; NaN if chain empty or IV missing."""
+    if chain_df is None or len(chain_df) == 0:
+        return float("nan")
+    idx = (chain_df["strike"] - spot).abs().idxmin()
+    return float(chain_df.loc[idx, "impliedVolatility"])
+
+
+def vix_sigma(days: int) -> float:
+    """Convert ^VIX (%) to annual sigma scaled to days-to-expiry."""
+    vix_pct = yf.Ticker("^VIX").history(period="1d")["Close"].iloc[-1] / 100.0
+    return vix_pct * math.sqrt(days / 30.0)
+
+
+def resolve_iv(raw_iv: float,
+               chain_df,
+               spot: float,
+               days: int,
+               floor: float = MIN_IV_DEFAULT):
+    """Return (iv, IVSource) after fallback: raw -> ATM -> VIX."""
+    if iv_is_valid(raw_iv, floor):
+        return raw_iv, IVSource.ORIG
+    iv = get_atm_iv(chain_df, spot)
+    if iv_is_valid(iv, floor):
+        return iv, IVSource.ATM
+    iv = vix_sigma(days)
+    return iv, IVSource.VIX


### PR DESCRIPTION
## Summary
- add `vol_utils` module for robust IV handling
- track IV sources via `IVSource` enum in `models` and spreads
- substitute low IV using ATM or VIX in option and spread analysis
- expose `--min-iv` flag and improve CLI table/heading
- document new IV handling logic
- include unit tests for IV fallback and CLI output

## Testing
- `pytest -q`