### PR TITLE
Implement IV fallback screener with width loops

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -27,18 +27,31 @@ python spy_options.py
 By default the script chooses the closest expiry and prints the best call
 option based on the simple heuristic above.
 
-## Credit-spread screener
+## Credit-Spread Screener
 
-The `cli.py` script screens SPY bull-put or bear-call credit spreads by probability-of-profit and credit percentage.
-
-Example:
+The `cli.py` script screens SPY bull-put or bear-call credit spreads.  Provide one or more widths and minimum IV threshold:
 
 ```bash
-python cli.py --type bull_put --pop 0.70 --credit 30
+python cli.py --type bull_put --widths 2 5 10 --pop 0.7 --credit 25 --min-iv 0.05
 ```
 
+Output columns:
+
+| Column   | Meaning                                   |
+|----------|-------------------------------------------|
+| Short    | Short strike price                        |
+| Long     | Long strike price                         |
+| Credit   | Net credit received                       |
+| MaxLoss  | Maximum possible loss                     |
+| Credit%  | Credit as percentage of spread width      |
+| PoP      | Theoretical probability of profit         |
+| IVs      | Short/long implied volatility values      |
+| Src      | IV sources for short/long legs            |
+| Days     | Calendar days to expiry                   |
+
 ### IV handling
-The screener replaces missing or near-zero implied volatility in two stages:
+
+Missing or too-low implied volatility is replaced in stages:
 
 | Source tag | Meaning |
 |------------|---------|
@@ -46,5 +59,5 @@ The screener replaces missing or near-zero implied volatility in two stages:
 | `atm`  | Missing IV replaced by at-the-money IV for that expiry |
 | `vix`  | Still missing → replaced by VIX-based σ scaled to expiry |
 
-Use `--min-iv` (default 0.05) to set the minimum acceptable IV after fallback.
+Use `--min-iv` to change the minimum acceptable IV (default `0.05`).
 

--- a/cli.py
+++ b/cli.py
@@ -10,7 +10,7 @@ from spread_analysis import SpreadType, get_credit_spreads, filter_credit_spread
 def main(args: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser(
         description="SPY credit-spread screener",
-        epilog="Outputs headings like '=== Bull-Put Spreads ~7 Market Days ==='",
+        epilog="Outputs headings like '=== Bull_Put Spreads ~7 Days | Width $5 ==='",
     )
     parser.add_argument(
         "--type",
@@ -19,7 +19,7 @@ def main(args: Optional[List[str]] = None) -> None:
     )
     parser.add_argument("--pop", type=float, default=0.65)
     parser.add_argument("--credit", dest="credit_pct", type=float, default=25.0)
-    parser.add_argument("--width", type=float, default=5.0)
+    parser.add_argument("--widths", nargs="+", type=float, default=[5.0])
     parser.add_argument(
         "--min-iv",
         type=float,
@@ -36,29 +36,33 @@ def main(args: Optional[List[str]] = None) -> None:
     expiries = oa.get_expiries_by_market_days([3, 7, 14, 21])
 
     for expiry in expiries:
-        spreads = get_credit_spreads(
-            expiry,
-            width=parsed.width,
-            spread_type=spread_type,
-            min_iv=parsed.min_iv,
-        )
-        spreads = filter_credit_spreads(spreads, pop_min=parsed.pop, credit_min_pct=parsed.credit_pct)
-        if not spreads:
-            continue
-        days = spreads[0].days_to_expiry
-        print(
-            f"=== {spread_type.value.replace('_','-').title()} Spreads ~{days} Market Days ==="
-        )
-        print(
-            f"{'Short':>5} {'Long':>5} {'Credit':>7} {'MaxLoss':>8} {'Credit%':>8} {'PoP':>5} {'IVs':>7} {'Src':>7} {'Days':>4}"
-        )
-        for sp in spreads:
-            ivs = f"{sp.short.iv:.2f}/{sp.long.iv:.2f}"
-            srcs = f"{sp.iv_short_src.value}/{sp.iv_long_src.value}"
-            print(
-                f"{sp.short.strike:5.0f} {sp.long.strike:5.0f} {sp.credit:7.2f} {sp.max_loss:8.2f} {sp.credit_pct:8.1f}% {sp.pop:5.2f} {ivs:>7} {srcs:>7} {sp.days_to_expiry:4d}"
+        for width in parsed.widths:
+            spreads = get_credit_spreads(
+                expiry,
+                width=width,
+                spread_type=spread_type,
+                min_iv=parsed.min_iv,
             )
-        print()
+            spreads = filter_credit_spreads(
+                spreads, pop_min=parsed.pop, credit_min_pct=parsed.credit_pct
+            )
+            if not spreads:
+                continue
+            days = spreads[0].days_to_expiry
+            stype = spread_type.value
+            print(
+                f"=== {stype.title()} Spreads ~{days} Days | Width ${width} ==="
+            )
+            print(
+                f"{'Short':>5} {'Long':>5} {'Credit':>7} {'MaxLoss':>8} {'Credit%':>8} {'PoP':>5} {'IVs':>7} {'Src':>9} {'Days':>4}"
+            )
+            for sp in spreads:
+                ivs = f"{sp.short.iv:.2f}/{sp.long.iv:.2f}"
+                srcs = f"{sp.iv_short_src.value}/{sp.iv_long_src.value}"
+                print(
+                    f"{sp.short.strike:5.0f} {sp.long.strike:5.0f} {sp.credit:7.2f} {sp.max_loss:8.2f} {sp.credit_pct:8.1f}% {sp.pop:5.2f} {ivs:>7} {srcs:>9} {sp.days_to_expiry:4d}"
+                )
+            print()
 
 
 if __name__ == "__main__":

--- a/models.py
+++ b/models.py
@@ -14,9 +14,9 @@ class OptionContract:
     expiry: dt.date
     option_type: str  # "call" or "put"
     last_price: float
-    iv: Optional[float] = None
-    iv_src: IVSource | None = None
-    underlying_price: Optional[float] = None
+    iv: float
+    iv_src: IVSource
+    underlying_price: float
     symbol: Optional[str] = None
     open_interest: Optional[int] = None
 

--- a/spy_options.py
+++ b/spy_options.py
@@ -16,6 +16,7 @@ import argparse
 import csv
 
 from models import OptionContract
+from vol_utils import IVSource
 import option_analysis as oa
 
 import pandas as pd
@@ -67,6 +68,9 @@ def find_best_option(expiry: str, option_type: str = "call") -> Optional[OptionC
         expiry=dt.datetime.strptime(expiry, "%Y-%m-%d").date(),
         option_type=option_type,
         last_price=float(best["lastPrice"]),
+        iv=float(best.get("impliedVolatility", 0.0)),
+        iv_src=IVSource.ORIG,
+        underlying_price=price,
         open_interest=int(best["openInterest"]),
     )
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -6,6 +6,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import option_analysis as oa
+from vol_utils import IVSource
 
 
 class OptionAnalysisTests(unittest.TestCase):
@@ -24,6 +25,7 @@ class OptionAnalysisTests(unittest.TestCase):
             strike=strike,
             last_price=price,
             iv=self.iv,
+            iv_src=IVSource.ORIG,
             expiry=self.expiry,
             option_type="call",
             underlying_price=self.underlying,

--- a/tests/test_vol.py
+++ b/tests/test_vol.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pandas as pd
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from vol_utils import resolve_iv, IVSource
+from vol_utils import resolve_iv, iv_is_valid, IVSource
 
 
 class VolUtilsTests(unittest.TestCase):
@@ -31,6 +31,10 @@ class VolUtilsTests(unittest.TestCase):
         result = subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), "..", "cli.py"), "--help"], capture_output=True, text=True)
         self.assertIn("~", result.stdout)
         self.assertNotIn("\u2248", result.stdout)
+
+    def test_iv_is_valid_threshold(self):
+        self.assertTrue(iv_is_valid(0.1, 0.05))
+        self.assertFalse(iv_is_valid(0.04, 0.05))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update OptionContract dataclass with required `iv` and `iv_src`
- integrate IV fallback sources into screener and SPY helper
- overhaul CLI for multi-width analysis and min IV handling
- extend spread utilities and tests for width loops and IV sources
- document credit-spread screener usage and IV fallback logic
- run CI with Python 3.12

## Testing
- `pytest -q`