### PR TITLE
Implement expiries_within helper

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -30,10 +30,18 @@ def main(args: Optional[List[str]] = None) -> None:
             "Spreads are skipped if resulting IV < floor."
         ),
     )
+    parser.add_argument(
+        "--expiry-dates",
+        nargs="+",
+        help="Explicit expiry dates (YYYY-MM-DD). Uses expiries within 14 days if omitted.",
+    )
     parsed = parser.parse_args(args)
 
     spread_type = SpreadType(parsed.type)
-    expiries = oa.get_expiries_by_market_days([3, 7, 14, 21])
+    if parsed.expiry_dates:
+        expiries = parsed.expiry_dates
+    else:
+        expiries = oa.expiries_within()
 
     for expiry in expiries:
         for width in parsed.widths:

--- a/option_analysis.py
+++ b/option_analysis.py
@@ -75,6 +75,17 @@ def get_expiries_by_market_days(targets: List[int] = [3, 7, 14, 21]) -> List[str
     return selected
 
 
+def expiries_within(max_days: int = 14) -> List[str]:
+    """Return all SPY expiries within ``max_days`` calendar days."""
+    ticker = yf.Ticker("SPY")
+    expiries = ticker.options
+    today = dt.date.today()
+    expiry_dates = [dt.datetime.strptime(e, "%Y-%m-%d").date() for e in expiries]
+    selected = [exp for exp in expiry_dates if 0 <= (exp - today).days <= max_days]
+    selected.sort()
+    return [d.strftime("%Y-%m-%d") for d in selected]
+
+
 
 
 def compute_option_metrics(
@@ -189,6 +200,7 @@ __all__ = [
     "OptionAnalysis",
     "black_scholes_price",
     "compute_option_metrics",
+    "expiries_within",
     "get_expiries_by_market_days",
     "get_call_option_analysis",
     "filter_options_by_pop_and_timevalue_percent",

--- a/tests/test_expiries.py
+++ b/tests/test_expiries.py
@@ -1,0 +1,29 @@
+import datetime as dt
+import unittest
+from unittest.mock import patch
+
+import option_analysis as oa
+
+class ExpiryWithinTests(unittest.TestCase):
+    def test_expiries_within_sorted(self):
+        today = dt.date.today()
+        dates = [
+            today + dt.timedelta(days=d) for d in [1, 15, 7]
+        ]
+        options = [d.strftime("%Y-%m-%d") for d in dates]
+
+        class FakeTicker:
+            def __init__(self, opts):
+                self.options = opts
+
+        with patch("option_analysis.yf.Ticker", return_value=FakeTicker(options)):
+            res = oa.expiries_within(max_days=14)
+
+        expected = sorted(
+            (today + dt.timedelta(days=d)).strftime("%Y-%m-%d")
+            for d in [1, 7]
+        )
+        self.assertEqual(res, expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `expiries_within` to select SPY expiries within a given number of days
- expose new helper in `option_analysis.__all__`
- allow `cli.py` to accept `--expiry-dates` and use `expiries_within` by default
- test `expiries_within`

## Testing
- `pytest -q`