### PR TITLE
Add Edge metric for spread sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Output columns:
 | MaxLoss  | Maximum possible loss                     |
 | Credit%  | Credit as percentage of spread width      |
 | PoP      | Theoretical probability of profit         |
+| Edge     | Credit% multiplied by PoP                 |
 | IVs      | Short/long implied volatility values      |
 | Src      | IV sources for short/long legs            |
 | Days     | Calendar days to expiry                   |

--- a/cli.py
+++ b/cli.py
@@ -76,13 +76,13 @@ def main(args: Optional[List[str]] = None) -> None:
                 f"=== {stype.title()} Spreads ~{days} Days | Width ${width} ==="
             )
             print(
-                f"{'Short':>5} {'Long':>5} {'Credit':>7} {'MaxLoss':>8} {'Credit%':>8} {'PoP':>5} {'IVs':>7} {'Src':>9} {'Days':>4}"
+                f"{'Short':>5} {'Long':>5} {'Credit':>7} {'MaxLoss':>8} {'Credit%':>8} {'PoP':>5} {'Edge':>7} {'IVs':>7} {'Src':>9} {'Days':>4}"
             )
             for sp in spreads:
                 ivs = f"{sp.short.iv:.2f}/{sp.long.iv:.2f}"
                 srcs = f"{sp.iv_short_src.value}/{sp.iv_long_src.value}"
                 print(
-                    f"{sp.short.strike:5.0f} {sp.long.strike:5.0f} {sp.credit:7.2f} {sp.max_loss:8.2f} {sp.credit_pct:8.1f}% {sp.pop:5.2f} {ivs:>7} {srcs:>9} {sp.days_to_expiry:4d}"
+                    f"{sp.short.strike:5.0f} {sp.long.strike:5.0f} {sp.credit:7.2f} {sp.max_loss:8.2f} {sp.credit_pct:8.1f}% {sp.pop:5.2f} {sp.edge:7.2f} {ivs:>7} {srcs:>9} {sp.days_to_expiry:4d}"
                 )
             print()
 

--- a/spread_analysis.py
+++ b/spread_analysis.py
@@ -37,6 +37,11 @@ class Spread:
     iv_long_src: IVSource
     days_to_expiry: int
 
+    @property
+    def edge(self) -> float:
+        """Return combined credit percentage and probability of profit."""
+        return self.credit_pct * self.pop
+
 
 def make_spread(
     spread_type: SpreadType,
@@ -134,7 +139,7 @@ def filter_credit_spreads(
         for s in spreads
         if s.pop >= pop_min and s.credit_pct >= credit_min_pct
     ]
-    filtered.sort(key=lambda s: (-s.pop, -s.credit_pct))
+    filtered.sort(key=lambda s: s.edge, reverse=True)
     return filtered
 
 

--- a/tests/test_spread.py
+++ b/tests/test_spread.py
@@ -140,6 +140,18 @@ class SpreadTests(unittest.TestCase):
         self.assertEqual(s5.iv_short_src, sa.IVSource.VIX)
         self.assertEqual(s5.iv_long_src, sa.IVSource.VIX)
 
+    def test_filter_sorted_by_edge(self):
+        short_a = self._make_option(99, 2.0)
+        long_a = self._make_option(94, 0.5)
+        s_a = sa.make_spread(sa.SpreadType.BULL_PUT, short_a, long_a, today=self.today)
+
+        short_b = self._make_option(101, 4.0)
+        long_b = self._make_option(96, 0.8)
+        s_b = sa.make_spread(sa.SpreadType.BULL_PUT, short_b, long_b, today=self.today)
+
+        spreads = sa.filter_credit_spreads([s_a, s_b], pop_min=0.0, credit_min_pct=0.0)
+        self.assertEqual(spreads[0], s_b)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- show an Edge column in the CLI output
- compute `edge` inside `Spread` dataclass
- sort credit spreads by the new metric
- document the Edge column
- test that sorting honours Edge

## Testing
- `pytest -q`