### PR TITLE
Improve IV floor logic with EV, logging, and retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+logs/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ The `cli.py` script screens SPY bull-put or bear-call credit spreads.  Provide o
 python cli.py --type bull_put --widths 2 5 10 --pop 0.7 --credit 25 --min-iv 0.05
 ```
 
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--widths` | Spread widths to evaluate (default `2 3 5`) |
+| `--pop` | Minimum probability of profit |
+| `--credit` | Minimum credit percent of width |
+| `--min-iv` | Minimum acceptable implied volatility |
+| `--sigma-floor` | Floor for VIX-derived volatility (default 0.12) |
+| `--show-sigma` | Display σ column in output |
+| `--log-file` | Path for run log TSV |
+
 Output columns:
 
 | Column   | Meaning                                   |
@@ -45,10 +57,20 @@ Output columns:
 | MaxLoss  | Maximum possible loss                     |
 | Credit%  | Credit as percentage of spread width      |
 | PoP      | Theoretical probability of profit         |
-| Edge     | Credit% multiplied by PoP                 |
+| σ        | Volatility used for PoP calculation       |
+| EV       | Expected value of the spread              |
 | IVs      | Short/long implied volatility values      |
 | Src      | IV sources for short/long legs            |
 | Days     | Calendar days to expiry                   |
+
+Values in the σ column are highlighted yellow when below 10%. The EV column
+uses the formula:
+
+```
+win = credit * pop
+loss = (width - credit) * (1 - pop)
+EV = win - loss
+```
 
 ### IV handling
 
@@ -61,6 +83,8 @@ Missing or too-low implied volatility is replaced in stages:
 | `vix`  | Still missing → replaced by VIX-based σ scaled to expiry |
 
 Use `--min-iv` to change the minimum acceptable IV (default `0.05`).
+Use `--sigma-floor` to override the hard minimum volatility applied when
+falling back to the VIX (default `0.12`).
 
 ### Expiry selection
 By default the screener scans *every* listed SPY expiry within the next **14 calendar days**:

--- a/cli.py
+++ b/cli.py
@@ -2,13 +2,26 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import os
+import subprocess
 from typing import List, Optional
 
 import yfinance as yf
+try:
+    from colorama import Fore, Style, init as colorama_init
+except Exception:  # pragma: no cover - colorama optional
+    class _Dummy:
+        def __getattr__(self, name):
+            return ""
+
+    Fore = Style = _Dummy()
+    def colorama_init():
+        pass
 
 import option_analysis as oa
 from spread_analysis import SpreadType, get_credit_spreads, filter_credit_spreads
 import expiry_selector
+from utils import MIN_SIGMA, fetch_with_retry
 
 
 def main(args: Optional[List[str]] = None) -> None:
@@ -23,7 +36,7 @@ def main(args: Optional[List[str]] = None) -> None:
     )
     parser.add_argument("--pop", type=float, default=0.65)
     parser.add_argument("--credit", dest="credit_pct", type=float, default=25.0)
-    parser.add_argument("--widths", nargs="+", type=float, default=[5.0])
+    parser.add_argument("--widths", nargs="+", type=float, default=[2.0, 3.0, 5.0])
     parser.add_argument(
         "--min-iv",
         type=float,
@@ -45,7 +58,23 @@ def main(args: Optional[List[str]] = None) -> None:
         default=14,
         help="Analyze every expiry up to this many calendar days ahead (default 14)",
     )
+    parser.add_argument(
+        "--sigma-floor",
+        type=float,
+        default=MIN_SIGMA,
+        help="Override minimum volatility used when deriving VIX sigma",
+    )
+    parser.add_argument(
+        "--show-sigma",
+        action="store_true",
+        help="Display sigma column in results",
+    )
+    parser.add_argument(
+        "--log-file",
+        help="Write TSV run log to this file instead of logs/run-YYYYMMDD-HHMM.tsv",
+    )
     parsed = parser.parse_args(args)
+    colorama_init()
 
     spread_type = SpreadType(parsed.type)
     ticker = yf.Ticker("SPY")
@@ -53,9 +82,29 @@ def main(args: Optional[List[str]] = None) -> None:
     expiries = (
         explicit_list
         if explicit_list
-        else expiry_selector.expiries_within(ticker, max_days=parsed.max_days)
+        else fetch_with_retry(expiry_selector.expiries_within, ticker, max_days=parsed.max_days)
     )
     today = dt.date.today()
+
+    # run log
+    ts = dt.datetime.now().strftime("%Y%m%d-%H%M")
+    log_dir = "logs"
+    log_path = parsed.log_file or f"{log_dir}/run-{ts}.tsv"
+    try:
+        os.makedirs(log_dir, exist_ok=True)
+    except Exception:
+        pass
+    try:
+        sha = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True).strip()
+    except Exception:
+        sha = "unknown"
+    try:
+        with open(log_path, "a") as f:
+            f.write(
+                f"{ts}\t{' '.join(args or [])}\t{','.join(expiries)}\t{parsed.sigma_floor}\t{sha}\n"
+            )
+    except Exception:
+        pass
 
     for expiry in expiries:
         for width in parsed.widths:
@@ -64,26 +113,41 @@ def main(args: Optional[List[str]] = None) -> None:
                 width=width,
                 spread_type=spread_type,
                 min_iv=parsed.min_iv,
+                sigma_floor=parsed.sigma_floor,
             )
             spreads = filter_credit_spreads(
                 spreads, pop_min=parsed.pop, credit_min_pct=parsed.credit_pct
             )
             if not spreads:
+                print(f"--- No candidates for ${width}-wide ---")
                 continue
             days = spreads[0].days_to_expiry
             stype = spread_type.value
             print(
                 f"=== {stype.title()} Spreads ~{days} Days | Width ${width} ==="
             )
-            print(
-                f"{'Short':>5} {'Long':>5} {'Credit':>7} {'MaxLoss':>8} {'Credit%':>8} {'PoP':>5} {'Edge':>7} {'IVs':>7} {'Src':>9} {'Days':>4}"
+            header = (
+                f"{'Short':>5} {'Long':>5} {'Credit':>7} {'MaxLoss':>8} {'Credit%':>8} {'PoP':>5}"
             )
+            if parsed.show_sigma:
+                header += f" {'σ':>4}"
+            header += f" {'EV':>7} {'IVs':>7} {'Src':>9} {'Days':>4}"
+            print(header)
             for sp in spreads:
                 ivs = f"{sp.short.iv:.2f}/{sp.long.iv:.2f}"
                 srcs = f"{sp.iv_short_src.value}/{sp.iv_long_src.value}"
-                print(
-                    f"{sp.short.strike:5.0f} {sp.long.strike:5.0f} {sp.credit:7.2f} {sp.max_loss:8.2f} {sp.credit_pct:8.1f}% {sp.pop:5.2f} {sp.edge:7.2f} {ivs:>7} {srcs:>9} {sp.days_to_expiry:4d}"
+                sigma_txt = f"{sp.sigma_used:.2f}"
+                if sp.sigma_used < 0.10:
+                    sigma_txt = f"{Fore.YELLOW}{sigma_txt}{Style.RESET_ALL}"
+                row = (
+                    f"{sp.short.strike:5.0f} {sp.long.strike:5.0f} {sp.credit:7.2f} {sp.max_loss:8.2f} {sp.credit_pct:8.1f}% {sp.pop:5.2f}"
                 )
+                if parsed.show_sigma:
+                    row += f" {sigma_txt:>4}"
+                row += (
+                    f" {sp.expected_value:7.2f} {ivs:>7} {srcs:>9} {sp.days_to_expiry:4d}"
+                )
+                print(row)
             print()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pandas
 yfinance
 pytest
+colorama>=0.4
+click>=8

--- a/spy_options.py
+++ b/spy_options.py
@@ -22,13 +22,15 @@ import option_analysis as oa
 import pandas as pd
 import yfinance as yf
 
+from utils import fetch_with_retry
+
 
 
 
 def get_latest_spy_price() -> float:
     """Return the latest SPY price using yfinance."""
     ticker = yf.Ticker("SPY")
-    data = ticker.history(period="1d")
+    data = fetch_with_retry(ticker.history, period="1d")
     if data.empty:
         raise RuntimeError("No data returned for SPY")
     return float(data["Close"].iloc[-1])
@@ -37,7 +39,7 @@ def get_latest_spy_price() -> float:
 def get_options_chain(expiry: str) -> pd.DataFrame:
     """Return the options chain for SPY for the given expiry date."""
     ticker = yf.Ticker("SPY")
-    opt = ticker.option_chain(expiry)
+    opt = fetch_with_retry(ticker.option_chain, expiry)
     calls = opt.calls.assign(option_type="call")
     puts = opt.puts.assign(option_type="put")
     chain = pd.concat([calls, puts], ignore_index=True)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,27 @@
+import sys
+import pandas as pd
+from types import SimpleNamespace
+
+class FakeTicker:
+    def __init__(self, *args, **kwargs):
+        import datetime as dt
+        self.options = [(dt.date.today() + dt.timedelta(days=3)).strftime("%Y-%m-%d")]
+
+    def history(self, period="1d"):
+        return pd.DataFrame({"Close": [100.0]})
+
+    def option_chain(self, expiry):
+        df = pd.DataFrame({
+            "strike": [95, 93],
+            "lastPrice": [1.5, 0.5],
+            "impliedVolatility": [0.2, 0.2],
+        })
+        return SimpleNamespace(calls=df, puts=df)
+
+
+def test_cli_runs(monkeypatch, capsys):
+    from cli import main
+    monkeypatch.setattr("yfinance.Ticker", lambda *a, **k: FakeTicker())
+    main(["--type", "bull_put", "--max-days", "3", "--widths", "2", "--show-sigma"])
+    captured = capsys.readouterr()
+    assert "Spreads" in captured.out

--- a/tests/test_spread.py
+++ b/tests/test_spread.py
@@ -140,7 +140,7 @@ class SpreadTests(unittest.TestCase):
         self.assertEqual(s5.iv_short_src, sa.IVSource.VIX)
         self.assertEqual(s5.iv_long_src, sa.IVSource.VIX)
 
-    def test_filter_sorted_by_edge(self):
+    def test_filter_sorted_by_ev(self):
         short_a = self._make_option(99, 2.0)
         long_a = self._make_option(94, 0.5)
         s_a = sa.make_spread(sa.SpreadType.BULL_PUT, short_a, long_a, today=self.today)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import time
+from typing import Any, Callable, Dict, Tuple
+
+MIN_SIGMA = 0.12  # 12 vol hard floor
+
+
+def capped_sigma(raw_sigma: float, floor: float = MIN_SIGMA) -> float:
+    """Return sigma respecting the minimum floor."""
+    return max(raw_sigma, floor)
+
+
+_fetch_cache: Dict[Tuple[str, Tuple[Any, ...], Tuple[Tuple[str, Any], ...]], Any] = {}
+
+
+def fetch_with_retry(func: Callable[..., Any], *args: Any, retries: int = 3, delay: float = 1.0, **kwargs: Any) -> Any:
+    """Call ``func`` with retries and simple caching."""
+    key = (getattr(func, "__qualname__", repr(func)), args, tuple(sorted(kwargs.items())))
+    if key in _fetch_cache:
+        return _fetch_cache[key]
+    last_exc: Exception | None = None
+    for _ in range(retries):
+        try:
+            result = func(*args, **kwargs)
+            _fetch_cache[key] = result
+            return result
+        except Exception as exc:  # pragma: no cover - network errors hard to simulate
+            last_exc = exc
+            time.sleep(delay)
+    if last_exc:
+        raise last_exc
+    raise RuntimeError("fetch_with_retry failed")


### PR DESCRIPTION
## Summary
- add utils with capped sigma and fetch_with_retry helpers
- track sigma used and expected value for spreads
- show EV and sigma columns in CLI output with optional colour
- add yfinance retry logic and run logging
- create smoke test for CLI
- document new flags and behaviour in README

## Testing
- `pytest -q`
