### PR TITLE
Add GA optimization notebook

### DIFF
--- a/notebooks/ga_optimize_credit_spread.ipynb
+++ b/notebooks/ga_optimize_credit_spread.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Genetic Algorithm Optimization of Credit Spreads\n",
+    "This notebook searches for the best parameter set for `synthetic_market.run_simulation()` using a genetic algorithm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%pip install -q pandas numpy matplotlib deap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import random\n",
+    "from deap import base, creator, tools\n",
+    "import synthetic_market as sm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The genetic algorithm explores a small range of strategy parameters. Fitness is defined as total return minus maximum drawdown."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "SEARCH_BOUNDS = dict(\n",
+    "    ema_period =(20, 100), # int\n",
+    "    risk_fraction =(0.01, 0.06),# float\n",
+    "    short_leg_low =(5, 20), # float (min distance)\n",
+    "    short_leg_high =(10, 30), # float (max distance, must \u2265 low)\n",
+    "    spread_w_low =(1, 5), # int\n",
+    "    spread_w_high =(4, 10), # int (\u2265 low)\n",
+    "    trade_credit_ratio=(0.2, 0.5), # float\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "random.seed(0)\n",
+    "np.random.seed(0)\n",
+    "\n",
+    "creator.create('FitnessMax', base.Fitness, weights=(1.0,))\n",
+    "creator.create('Individual', list, fitness=creator.FitnessMax)\n",
+    "\n",
+    "def gen_ind():\n",
+    "    b = SEARCH_BOUNDS\n",
+    "    return creator.Individual([\n",
+    "        np.random.randint(b['ema_period'][0], b['ema_period'][1] + 1),\n",
+    "        np.random.uniform(*b['risk_fraction']),\n",
+    "        np.random.uniform(*b['short_leg_low']),\n",
+    "        np.random.uniform(*b['short_leg_high']),\n",
+    "        np.random.randint(b['spread_w_low'][0], b['spread_w_low'][1] + 1),\n",
+    "        np.random.randint(b['spread_w_high'][0], b['spread_w_high'][1] + 1),\n",
+    "        np.random.uniform(*b['trade_credit_ratio']),\n",
+    "    ])\n",
+    "\n",
+    "def mate(i1, i2):\n",
+    "    tools.cxOnePoint(i1, i2)\n",
+    "    return i1, i2\n",
+    "\n",
+    "def mutate(ind):\n",
+    "    ind[0] = int(np.clip(ind[0] + int(random.gauss(0,5)), *SEARCH_BOUNDS['ema_period']))\n",
+    "    ind[1] = float(np.clip(ind[1] + random.gauss(0,0.005), *SEARCH_BOUNDS['risk_fraction']))\n",
+    "    ind[2] = float(np.clip(ind[2] + random.gauss(0,1), *SEARCH_BOUNDS['short_leg_low']))\n",
+    "    ind[3] = float(np.clip(ind[3] + random.gauss(0,1), *SEARCH_BOUNDS['short_leg_high']))\n",
+    "    ind[4] = int(np.clip(ind[4] + int(random.gauss(0,1)), *SEARCH_BOUNDS['spread_w_low']))\n",
+    "    ind[5] = int(np.clip(ind[5] + int(random.gauss(0,1)), *SEARCH_BOUNDS['spread_w_high']))\n",
+    "    ind[6] = float(np.clip(ind[6] + random.gauss(0,0.02), *SEARCH_BOUNDS['trade_credit_ratio']))\n",
+    "    if ind[3] < ind[2]:\n",
+    "        ind[3] = ind[2]\n",
+    "    if ind[5] < ind[4]:\n",
+    "        ind[5] = ind[4]\n",
+    "    return (ind,)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def eval_ind(ind):\n",
+    "    keys = list(SEARCH_BOUNDS)\n",
+    "    cfg = {\n",
+    "        'ema_period': int(ind[0]),\n",
+    "        'risk_fraction': ind[1],\n",
+    "        'short_leg_distance': (ind[2], ind[3]),\n",
+    "        'spread_width_range': (int(ind[4]), int(ind[5])),\n",
+    "        'trade_credit_ratio': ind[6],\n",
+    "        'seed': 123,\n",
+    "    }\n",
+    "    res = sm.run_simulation(cfg)\n",
+    "    score = res.total_return - res.max_drawdown\n",
+    "    return (score,)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "toolbox = base.Toolbox()\n",
+    "toolbox.register('individual', gen_ind)\n",
+    "toolbox.register('population', tools.initRepeat, list, toolbox.individual)\n",
+    "toolbox.register('mate', mate)\n",
+    "toolbox.register('mutate', mutate)\n",
+    "toolbox.register('select', tools.selTournament, tournsize=3)\n",
+    "toolbox.register('evaluate', eval_ind)\n",
+    "\n",
+    "POP = 40\n",
+    "GENS = 25\n",
+    "CX = 0.5\n",
+    "MUT = 0.3\n",
+    "\n",
+    "pop = toolbox.population(n=POP)\n",
+    "best_scores = []\n",
+    "\n",
+    "for g in range(GENS):\n",
+    "    fits = list(map(toolbox.evaluate, pop))\n",
+    "    for ind, fit in zip(pop, fits):\n",
+    "        ind.fitness.values = fit\n",
+    "    best = tools.selBest(pop, 1)[0]\n",
+    "    best_scores.append(best.fitness.values[0])\n",
+    "\n",
+    "    offspring = toolbox.select(pop, len(pop))\n",
+    "    offspring = list(map(toolbox.clone, offspring))\n",
+    "\n",
+    "    for c1, c2 in zip(offspring[::2], offspring[1::2]):\n",
+    "        if random.random() < CX:\n",
+    "            toolbox.mate(c1, c2)\n",
+    "            del c1.fitness.values, c2.fitness.values\n",
+    "\n",
+    "    for ind in offspring:\n",
+    "        if random.random() < MUT:\n",
+    "            toolbox.mutate(ind)\n",
+    "            del ind.fitness.values\n",
+    "\n",
+    "    invalid = [ind for ind in offspring if not ind.fitness.valid]\n",
+    "    fits = map(toolbox.evaluate, invalid)\n",
+    "    for ind, fit in zip(invalid, fits):\n",
+    "        ind.fitness.values = fit\n",
+    "\n",
+    "    pop[:] = offspring\n",
+    "\n",
+    "champ = tools.selBest(pop, 1)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "plt.figure(figsize=(6,4))\n",
+    "plt.plot(best_scores, marker='o')\n",
+    "plt.xlabel('Generation')\n",
+    "plt.ylabel('Best Fitness')\n",
+    "plt.title('Best Fitness by Generation')\n",
+    "plt.show()\n",
+    "\n",
+    "champ_cfg = {\n",
+    "    'ema_period': int(champ[0]),\n",
+    "    'risk_fraction': champ[1],\n",
+    "    'short_leg_distance': (champ[2], champ[3]),\n",
+    "    'spread_width_range': (int(champ[4]), int(champ[5])),\n",
+    "    'trade_credit_ratio': champ[6],\n",
+    "    'seed': 123,\n",
+    "}\n",
+    "result = sm.run_simulation(champ_cfg)\n",
+    "result.equity_curve.set_index('Date')['Equity'].plot(figsize=(8,4))\n",
+    "plt.title('Equity Curve of Champion')\n",
+    "plt.ylabel('Equity')\n",
+    "plt.show()\n",
+    "\n",
+    "print('Champion params:', champ_cfg)\n",
+    "print('Fitness (ret \u2212 DD):', round(result.total_return - result.max_drawdown, 3))\n",
+    "print('Total return:', round(result.total_return * 100, 1), '%')\n",
+    "print('Max DD:', round(result.max_drawdown * 100, 1), '%')\n",
+    "print('Win rate:', round(result.win_rate * 100, 1), '%')\n",
+    "print('Trades:', len(result.trades))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Champion Parameters\n",
+    "- `ema_period`: ...\n",
+    "- `risk_fraction`: ...\n",
+    "- `short_leg_distance`: ...\n",
+    "- `spread_width_range`: ...\n",
+    "- `trade_credit_ratio`: ..."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook demonstrating GA optimization for the credit spread simulation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d5ef33a9483279da415681908cbde