### PR TITLE
Fix notebook field compliance

### DIFF
--- a/notebooks/ga_optimize_credit_spread.ipynb
+++ b/notebooks/ga_optimize_credit_spread.ipynb
@@ -13,7 +13,9 @@
    "metadata": {},
    "source": [
     "%pip install -q pandas numpy matplotlib deap"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -25,7 +27,9 @@
     "import random\n",
     "from deap import base, creator, tools\n",
     "import synthetic_market as sm"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -42,12 +46,14 @@
     "    ema_period =(20, 100), # int\n",
     "    risk_fraction =(0.01, 0.06),# float\n",
     "    short_leg_low =(5, 20), # float (min distance)\n",
-    "    short_leg_high =(10, 30), # float (max distance, must \u2265 low)\n",
+    "    short_leg_high =(10, 30), # float (max distance, must ≥ low)\n",
     "    spread_w_low =(1, 5), # int\n",
-    "    spread_w_high =(4, 10), # int (\u2265 low)\n",
+    "    spread_w_high =(4, 10), # int (≥ low)\n",
     "    trade_credit_ratio=(0.2, 0.5), # float\n",
     ")"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -88,7 +94,9 @@
     "    if ind[5] < ind[4]:\n",
     "        ind[5] = ind[4]\n",
     "    return (ind,)"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -107,7 +115,9 @@
     "    res = sm.run_simulation(cfg)\n",
     "    score = res.total_return - res.max_drawdown\n",
     "    return (score,)"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -157,7 +167,9 @@
     "    pop[:] = offspring\n",
     "\n",
     "champ = tools.selBest(pop, 1)[0]"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -185,12 +197,14 @@
     "plt.show()\n",
     "\n",
     "print('Champion params:', champ_cfg)\n",
-    "print('Fitness (ret \u2212 DD):', round(result.total_return - result.max_drawdown, 3))\n",
+    "print('Fitness (ret − DD):', round(result.total_return - result.max_drawdown, 3))\n",
     "print('Total return:', round(result.total_return * 100, 1), '%')\n",
     "print('Max DD:', round(result.max_drawdown * 100, 1), '%')\n",
     "print('Win rate:', round(result.win_rate * 100, 1), '%')\n",
     "print('Trades:', len(result.trades))"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- add `execution_count` and `outputs` fields to code cells in the GA optimization notebook

## Testing
- `pytest -q`
- `jupyter nbconvert --validate notebooks/ga_optimize_credit_spread.ipynb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d60c315248327b3e091164c29d367