### PR TITLE
Add repo setup cell and refine Heston API

### DIFF
--- a/notebooks/ga_optimize_credit_spread.ipynb
+++ b/notebooks/ga_optimize_credit_spread.ipynb
@@ -25,7 +25,18 @@
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "import random\n",
-    "from deap import base, creator, tools\n",
+    "from deap import base, creator, tools\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "!git clone https://github.com/rpmiller4/CodexFun.git\n",
+    "%cd CodexFun\n",
+    "\n",
     "import synthetic_market as sm"
    ],
    "execution_count": null,
@@ -46,9 +57,9 @@
     "    ema_period =(20, 100), # int\n",
     "    risk_fraction =(0.01, 0.06),# float\n",
     "    short_leg_low =(5, 20), # float (min distance)\n",
-    "    short_leg_high =(10, 30), # float (max distance, must ≥ low)\n",
+    "    short_leg_high =(10, 30), # float (max distance, must \u2265 low)\n",
     "    spread_w_low =(1, 5), # int\n",
-    "    spread_w_high =(4, 10), # int (≥ low)\n",
+    "    spread_w_high =(4, 10), # int (\u2265 low)\n",
     "    trade_credit_ratio=(0.2, 0.5), # float\n",
     ")"
    ],
@@ -197,7 +208,7 @@
     "plt.show()\n",
     "\n",
     "print('Champion params:', champ_cfg)\n",
-    "print('Fitness (ret − DD):', round(result.total_return - result.max_drawdown, 3))\n",
+    "print('Fitness (ret \u2212 DD):', round(result.total_return - result.max_drawdown, 3))\n",
     "print('Total return:', round(result.total_return * 100, 1), '%')\n",
     "print('Max DD:', round(result.max_drawdown * 100, 1), '%')\n",
     "print('Win rate:', round(result.win_rate * 100, 1), '%')\n",

--- a/synthetic_market.py
+++ b/synthetic_market.py
@@ -38,6 +38,12 @@ DEFAULT_CONFIG: Dict[str, object] = {
     "end_date": "2025-12-31",
     "mu": 0.07,
     "sigma": 0.20,
+    "vol_model": "gbm",  # "gbm" or "heston"
+    "kappa": 1.5,
+    "theta": 0.04,
+    "xi": 0.3,
+    "rho": -0.7,
+    "v0": 0.04,
     "ema_period": 50,
     "risk_fraction": 0.03,
     "max_lots": 6,
@@ -71,6 +77,53 @@ def simulate_prices(
     return pd.DataFrame({"Date": dates.date, "Close": prices})
 
 
+def heston_path(
+    r: float,
+    kappa: float,
+    theta: float,
+    xi: float,
+    rho: float,
+    v0: float,
+    s0: float,
+    dt_frac: float,
+    steps: int,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return price and variance paths using Euler-Milstein discretisation."""
+    rng = np.random.default_rng(seed)
+    z1 = rng.standard_normal(steps)
+    z2 = rho * z1 + np.sqrt(1 - rho ** 2) * rng.standard_normal(steps)
+    v = np.empty(steps + 1)
+    s = np.empty(steps + 1)
+    v[0] = v0
+    s[0] = s0
+    for t in range(steps):
+        v[t + 1] = np.abs(v[t] + kappa * (theta - v[t]) * dt_frac + xi * np.sqrt(v[t] * dt_frac) * z2[t])
+        s[t + 1] = s[t] * np.exp((r - 0.5 * v[t]) * dt_frac + np.sqrt(v[t] * dt_frac) * z1[t])
+    return s, v
+
+
+def simulate_prices_heston(
+    start_price: float,
+    start_date: dt.date,
+    end_date: dt.date,
+    mu: float,
+    kappa: float,
+    theta: float,
+    xi: float,
+    rho: float,
+    v0: float,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Return DataFrame of prices simulated via the Heston model."""
+    dates = pd.date_range(start_date, end_date, freq="D")
+    steps = len(dates) - 1
+    dt_frac = 1 / 252.0
+    # use risk-neutral drift equal to the mean return
+    s, _ = heston_path(mu, kappa, theta, xi, rho, v0, start_price, dt_frac, steps, seed)
+    return pd.DataFrame({"Date": dates.date, "Close": s})
+
+
 def compute_ema(series: pd.Series, period: int) -> pd.Series:
     """Return exponential moving average for ``series``."""
     return series.ewm(span=period, adjust=False).mean()
@@ -80,14 +133,28 @@ def run_simulation(config: Dict[str, object] | None = None) -> SimulationResult:
     cfg = {**DEFAULT_CONFIG, **(config or {})}
     start_date = dt.datetime.strptime(str(cfg["start_date"]), "%Y-%m-%d").date()
     end_date = dt.datetime.strptime(str(cfg["end_date"]), "%Y-%m-%d").date()
-    prices = simulate_prices(
-        start_price=float(cfg["start_price"]),
-        start_date=start_date,
-        end_date=end_date,
-        mu=float(cfg["mu"]),
-        sigma=float(cfg["sigma"]),
-        seed=int(cfg.get("seed", 0)),
-    )
+    if cfg.get("vol_model") == "heston":
+        prices = simulate_prices_heston(
+            start_price=float(cfg["start_price"]),
+            start_date=start_date,
+            end_date=end_date,
+            mu=float(cfg["mu"]),
+            kappa=float(cfg["kappa"]),
+            theta=float(cfg["theta"]),
+            xi=float(cfg["xi"]),
+            rho=float(cfg["rho"]),
+            v0=float(cfg["v0"]),
+            seed=int(cfg.get("seed", 0)),
+        )
+    else:
+        prices = simulate_prices(
+            start_price=float(cfg["start_price"]),
+            start_date=start_date,
+            end_date=end_date,
+            mu=float(cfg["mu"]),
+            sigma=float(cfg["sigma"]),
+            seed=int(cfg.get("seed", 0)),
+        )
     prices["EMA"] = compute_ema(prices["Close"], int(cfg["ema_period"]))
 
     capital = 10000.0
@@ -196,6 +263,8 @@ def run_simulation(config: Dict[str, object] | None = None) -> SimulationResult:
 
 __all__ = [
     "simulate_prices",
+    "simulate_prices_heston",
+    "heston_path",
     "compute_ema",
     "run_simulation",
     "Trade",

--- a/tests/test_synthetic_market.py
+++ b/tests/test_synthetic_market.py
@@ -20,6 +20,24 @@ class SyntheticMarketTests(unittest.TestCase):
         p2 = sm.simulate_prices(100.0, dt.date(2023,1,1), dt.date(2023,12,31), 0.05, 0.2, seed=42)
         self.assertTrue((p1['Close'] == p2['Close']).all())
 
+    def test_heston_price_determinism(self):
+        cfg = {
+            "start_price": 100.0,
+            "start_date": "2023-01-01",
+            "end_date": "2023-03-31",
+            "mu": 0.05,
+            "vol_model": "heston",
+            "kappa": 1.0,
+            "theta": 0.04,
+            "xi": 0.2,
+            "rho": -0.5,
+            "v0": 0.04,
+            "seed": 42,
+        }
+        p1 = sm.run_simulation(cfg)
+        p2 = sm.run_simulation(cfg)
+        self.assertAlmostEqual(p1.total_return, p2.total_return)
+
     def test_run_simulation(self):
         cfg = {
             "start_price": 100.0,
@@ -33,6 +51,19 @@ class SyntheticMarketTests(unittest.TestCase):
         self.assertGreater(len(res.trades), 0)
         self.assertIn('Equity', res.equity_curve.columns)
         # deterministic result for given seed
+        res2 = sm.run_simulation(cfg)
+        self.assertAlmostEqual(res.total_return, res2.total_return)
+
+    def test_run_simulation_heston(self):
+        cfg = {
+            "start_price": 100.0,
+            "start_date": "2022-01-01",
+            "end_date": "2022-12-31",
+            "mu": 0.05,
+            "vol_model": "heston",
+            "seed": 7,
+        }
+        res = sm.run_simulation(cfg)
         res2 = sm.run_simulation(cfg)
         self.assertAlmostEqual(res.total_return, res2.total_return)
 


### PR DESCRIPTION
## Summary
- clean up unused parameter in `heston_path`
- add notebook cell with clone instructions
- keep imports separate from repository setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d61aeb92083278f43c718d17ed7c1